### PR TITLE
Added ability to obtain file downloaded to shell adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "hubot-scripts",
     "slack",
     "facebook",
-		"ibm cloud",
-		"attachment formatter"
+    "ibm cloud",
+    "attachment formatter"
   ],
   "author": "ibm-cloud-solutions",
   "license": "Apache-2.0",
@@ -46,6 +46,7 @@
     "index.js"
   ],
   "dependencies": {
+    "i18n-2": "^0.6.3",
     "lodash": "^4.13.1",
     "marked": "^0.3.5",
     "request": "^2.74.0"

--- a/src/lib/textFormatter.js
+++ b/src/lib/textFormatter.js
@@ -96,9 +96,10 @@ module.exports = (robot, attachment) => {
 		});
 	}
 	else if (attachment && attachment.filePath && attachment.fileName) {
-		fs.unlinkSync(attachment.filePath);
-		robot.logger.debug(`${TAG}: Uploading file is not supported`);
-		responseMessage = `Uploading file is not supported for ${robot.adapterName} adapter.`;
+		let pathToFile = fs.realpathSync(attachment.filePath);
+
+		robot.logger.debug(`${TAG}: File downloaded and available ${pathToFile}`);
+		responseMessage = `File downloaded and available ${pathToFile}`;
 	}
 	else if (attachment && attachment.attachments) {
 		// Handle attachments, formatting into an ascii table.

--- a/src/lib/textFormatter.js
+++ b/src/lib/textFormatter.js
@@ -13,6 +13,18 @@ const fs = require('fs');
 const _ = require('lodash');
 const marked = require('marked');
 
+const i18n = new (require('i18n-2'))({
+	locales: ['en'],
+	extension: '.json',
+	// Add more languages to the list of locales when the files are created.
+	directory: __dirname + '/../messages',
+	defaultLocale: 'en',
+	// Prevent messages file from being overwritten in error conditions (like poor JSON).
+	updateFiles: false
+});
+// At some point we need to toggle this setting based on some user input.
+i18n.setLocale('en');
+
 // -------------------------------------------------------
 // Custom renderer to strip out all markdown formatting
 // included in messages.
@@ -99,7 +111,7 @@ module.exports = (robot, attachment) => {
 		let pathToFile = fs.realpathSync(attachment.filePath);
 
 		robot.logger.debug(`${TAG}: File downloaded and available ${pathToFile}`);
-		responseMessage = `File downloaded and available ${pathToFile}`;
+		responseMessage = i18n.__('formatter.file.downloaded', pathToFile);
 	}
 	else if (attachment && attachment.attachments) {
 		// Handle attachments, formatting into an ascii table.
@@ -126,7 +138,7 @@ module.exports = (robot, attachment) => {
 		responseMessage = asciiToTable(responseMessage);
 	}
 	else {
-		responseMessage = 'No results found';
+		responseMessage = i18n.__('formatter.no.results.found');
 	}
 
 	robot.logger.debug(`${TAG}: Sending response - ${responseMessage}`);

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,0 +1,8 @@
+{
+	"formatter.file.downloaded": "File downloaded and available %s",
+	"formatter.no.results.found": "No results found",
+
+	"conversation.timed.out": "Our conversation timed out.  You can try again later.",
+	"conversation.try.again.or.exit": "That is not one of the choices. Try again, or type *exit*.",
+	"conversation.try.again.yes.no": "That is not one of the choices. Try *yes* or *no*."
+}

--- a/test/textFormatter.test.js
+++ b/test/textFormatter.test.js
@@ -58,10 +58,11 @@ describe('Interacting with the Plain Text Transformer', function() {
 			}
 		};
 
+		let pathToFile = fs.realpathSync(fileName);
 		payload.response.send = sinon.spy();
 
 		formatter(robot, payload);
-		expect(payload.response.send).to.have.been.calledWith('Uploading file is not supported for shell adapter.');
+		expect(payload.response.send).to.have.been.calledWith(`File downloaded and available ${pathToFile}`);
 		if (fs.exists(fileName))
 			fs.unlinkSync(fileName);
 	});


### PR DESCRIPTION
Fixes #4 

> . test/.env && mocha test

  Interacting with the Facebook Transformer
    ✓ should attempt to uploadfile
    ✓ should update the response envelope
    ✓ should reply with a properly formatted response
    ✓ long request should reply with several payloads
    ✓ should handle an empty payload
    ✓ should handle only field payload
    ✓ should handle no fields
    ✓ should handle no title but yes text
    ✓ should handle title with more than 80 characters
    ✓ should promote field values in the absence of titles
    ✓ should be an emptry string when there are fields with only empty title/value
    ✓ should handle the absence of title, text, and fields
    ✓ should handle image_url
    ✓ should handle thumb_url
    ✓ should handle author_icon
    ✓ should handle footer_icon
    ✓ should handle fallback
    ✓ should extract a content url
    ✓ should reply with a properly formatted response
    ✓ should repalce escapable characters with unicode equivalents

  Interacting with Bluemix via Slack
    user says something hubot does not care about
      ✓ should not respond

  Interacting with the IBM Cloud Formatter
    Registering the listener
      ✓ should add a callback for the ibmcloud.formatter event
    Picking the proper formatter
      ✓ should use the Slack formatter when the slack adapter is used
      ✓ should use the text formatter when an unkown adapter type is used
      ✓ should prepend robot's name to message when using fb adapter
      ✓ should not prepend robot's name to message when using non-fb adapter

  Interacting with the Slack Transformer
    ✓ should attempt to uploadfile
    ✓ should emit a slack.attachment event
    ✓ > 50 attachments should emit a multiple slack.attachment events
    ✓ should reply with a properly formatted response
    ✓ should repalce escapable characters with unicode equivalents

  Interacting with the Plain Text Transformer
    ✓ should not emit an event
    ✓ should attempt to uploadfile
    ✓ should format attachment titles and text
    ✓ should format attachment fields
    ✓ should reply with a properly formatted response
    ✓ should repalce escapable characters with unicode equivalents

  Interacting with the Web Transformer
    ✓ should not emit an event
    ✓ should attempt to uploadfile
    ✓ should format attachment titles and text
    ✓ should format attachment fields
    ✓ should format attachment fields without the short property
    ✓ should format attachment fields with the short property
    ✓ should format attachment fields where only one field is short
    ✓ should format attachment fields where there is text before the table
    ✓ should format attachment images
    ✓ should repalce escapable characters with unicode equivalents

  47 passing (225ms)
